### PR TITLE
Reference correct line numbers

### DIFF
--- a/drake/doc/autodiff_intro/autodiff.tex
+++ b/drake/doc/autodiff_intro/autodiff.tex
@@ -150,8 +150,8 @@ which is as we should expect.
 Some points of interest are listed below:
 \begin{description}
  \item [\textbf{Line 7} ]\quad This statement may be necessary for your compiler to distinguish between the AutoDiff'd \texttt{sin} function and the C++ standard library version.
- \item [\textbf{Line 14} ]\quad This sets the value of the independent variable, $x$, \emph{at the point at which the derivative is to be evaluated}.
- \item [\textbf{Line 15}\ ]\quad This line is necessary to obtain the derivative of \texttt{sin} with respect to \texttt{x} on return from \texttt{sin\_T}. I'll discuss below why it needs to be set to this seemingly arbitrary value.
+ \item [\textbf{Line 13} ]\quad This sets the value of the independent variable, $x$, \emph{at the point at which the derivative is to be evaluated}.
+ \item [\textbf{Line 14}\ ]\quad This line is necessary to obtain the derivative of \texttt{sin} with respect to \texttt{x} on return from \texttt{sin\_T}. I'll discuss below why it needs to be set to this seemingly arbitrary value.
 \end{description}
 
 \raggedright


### PR DESCRIPTION
This shifts the references 14,15 -> 13, 14 as they should be. Previous sample from the pdf:

```
13 AScalar x = 3∗M PI / 4 . 0 ;
14 x.derivatives()(0) = 1;
15 cout << ”sin(x) = ” << sinT(x).value() << ” for x = ” << x.value() << endl;
...
Some points of interest are listed below:
Line 7 This statement may be necessary for your compiler to distinguish between the AutoDiff’d
sin function and the C++ standard library version.
Line 14 This sets the value of the independent variable, x, at the point at which the derivative is to
be evaluated.
Line 15 This line is necessary to obtain the derivative of sin with respect to x on return from sin_T.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/edrumwri/drake/6)
<!-- Reviewable:end -->
